### PR TITLE
Removed deprecated call to Class.newInstance

### DIFF
--- a/src/main/java/horseshoe/RenderSection.java
+++ b/src/main/java/horseshoe/RenderSection.java
@@ -30,9 +30,9 @@ class RenderSection implements Action {
 
 		try { // Try to load the Java 8+ version
 			if (Properties.JAVA_VERSION >= 8.0) {
-				factory = (Factory)Factory.class.getClassLoader().loadClass(Factory.class.getName().replace("RenderSectionAction", "RenderSectionAction_8")).newInstance();
+				factory = (Factory)Factory.class.getClassLoader().loadClass(Factory.class.getName().replace("RenderSectionAction", "RenderSectionAction_8")).getConstructor().newInstance();
 			}
-		} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+		} catch (final ReflectiveOperationException e) {
 		}
 
 		FACTORY = factory;

--- a/src/main/java/horseshoe/Resolver.java
+++ b/src/main/java/horseshoe/Resolver.java
@@ -92,9 +92,9 @@ abstract class Resolver {
 
 		try { // Try to load the Java 8+ version
 			if (Properties.JAVA_VERSION >= 8.0) {
-				factory = (Factory)Factory.class.getClassLoader().loadClass(Factory.class.getName().replace("Resolver", "Resolver_8")).newInstance();
+				factory = (Factory)Factory.class.getClassLoader().loadClass(Factory.class.getName().replace("Resolver", "Resolver_8")).getConstructor().newInstance();
 			}
-		} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+		} catch (final ReflectiveOperationException e) {
 		}
 
 		FACTORY = factory;


### PR DESCRIPTION
Java 9 deprecated `Class.newInstance()`, use `Class.getConstructor().newInstance()` instead.