### PR TITLE
Add partial include directory tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,4 +58,4 @@ task printVersion {
 	}
 }
 
-version = '0.1.21'
+version = '0.1.22'

--- a/src/main/java/horseshoe/TemplateLoader.java
+++ b/src/main/java/horseshoe/TemplateLoader.java
@@ -322,7 +322,7 @@ public class TemplateLoader {
 			try {
 				if (loader == null) {
 					// Try to load the template from the current template directory
-					final Path baseDirectory = loaders.isEmpty() ? Paths.get(".") : loaders.peek().getFile();
+					final Path baseDirectory = loaders.isEmpty() || loaders.peek().getFile() == null ? Paths.get(".") : loaders.peek().getFile().getParent();
 					final Path toLoadFromBase = baseDirectory == null ? null : baseDirectory.resolve(name).normalize();
 
 					if (toLoadFromBase != null && toLoadFromBase.toFile().isFile()) {
@@ -330,7 +330,7 @@ public class TemplateLoader {
 							loader = new Loader(name, toLoadFromBase, charset);
 						} else {
 							for (final Path directory : includeDirectories) {
-								if (toLoadFromBase.startsWith(directory)) {
+								if (toLoadFromBase.startsWith(directory.normalize())) {
 									loader = new Loader(name, toLoadFromBase, charset);
 									break;
 								}
@@ -342,7 +342,7 @@ public class TemplateLoader {
 						for (final Path directory : includeDirectories) {
 							final Path toLoad = directory.resolve(name).normalize();
 
-							if ((!preventPartialPathTraversal || toLoad.startsWith(directory)) && toLoad.toFile().isFile()) {
+							if ((!preventPartialPathTraversal || toLoad.startsWith(directory.normalize())) && toLoad.toFile().isFile()) {
 								loader = new Loader(name, toLoad, charset);
 								break;
 							}

--- a/src/test/java/horseshoe/PartialsDirectoryTests.java
+++ b/src/test/java/horseshoe/PartialsDirectoryTests.java
@@ -1,0 +1,89 @@
+package horseshoe;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class PartialsDirectoryTests {
+
+	public final @Rule TemporaryFolder temporaryFolder = new TemporaryFolder();
+	private final String rootIncludeDir;
+	private final File partialFilePath;
+	private final File partialNavigationPath;
+	private final boolean preventPartialPathTraversal;
+	private final Class<? super Exception> expectedException;
+
+	public PartialsDirectoryTests(final String rootIncludeDir,
+			final String partialFilePath,
+			final String partialNavigationPath,
+			final boolean preventPartialPathTraversal,
+			final Class<? super Exception> expectedException) {
+		this.rootIncludeDir = rootIncludeDir;
+		this.partialFilePath = new File(partialFilePath);
+		this.partialNavigationPath = new File(partialNavigationPath);
+		this.preventPartialPathTraversal = preventPartialPathTraversal;
+		this.expectedException = expectedException;
+	}
+
+	@Parameters(name = "rootIncludeDir = {0}, partialFilePath = {1}, partialNavigationPath = {2}, preventPartialPathTraversal = {3}, expectedException = {4}")
+	public static Collection<Object[]> data() {
+			return Arrays.asList(new Object[][] {
+					{ "./", "Partial", "Partial", true, null },
+					{ "./test1/test2", "Partial", "../../Partial", true, LoadException.class },
+					{ "./test1/test2", "Partial", "../../Partial", false, null },
+					{ "./test1/test3", "test1/test2/Partial", "../test2/Partial", true, LoadException.class },
+					{ "./test1/test3", "test1/test2/Partial", "../test2/Partial", false, null },
+			});
+	}
+
+	private void writeFileContents(final File file, final String contents) throws IOException {
+		try (final Writer writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8.newEncoder())) {
+			writer.write(contents);
+		}
+	}
+
+	@Test
+	public void testPartialFromOtherDirectory() throws IOException, LoadException {
+		if (partialFilePath.getParentFile() != null) {
+				temporaryFolder.newFolder(partialFilePath.getParentFile().toString().split("/"));
+		}
+		final File rootIncludeDir = new File(temporaryFolder.getRoot(), this.rootIncludeDir);
+		final File tempFile = temporaryFolder.newFile(partialFilePath.toString());
+		final String partialContent = "This partial renders text!";
+		writeFileContents(tempFile, partialContent);
+		final Settings settings = new Settings();
+		final TemplateLoader loader = new TemplateLoader(Arrays.asList(rootIncludeDir.toPath()))
+				.setPreventPartialPathTraversal(preventPartialPathTraversal)
+				.setThrowOnPartialNotFound(true);
+		Template template = null;
+		try {
+			template = loader.load("Test", "{{>" + partialNavigationPath + "}}");
+		} catch (final LoadException e) {
+			if (expectedException == null || !expectedException.isInstance(e)) {
+				throw e;
+			}
+		}
+		if (expectedException != null) {
+			throw new AssertionError("Expected exception: " + expectedException);
+		}
+		final StringWriter writer = new StringWriter();
+		template.render(settings, Collections.emptyMap(), writer);
+		Assert.assertEquals(partialContent, writer.toString());
+	}
+
+}

--- a/src/test/java/horseshoe/PartialsTests.java
+++ b/src/test/java/horseshoe/PartialsTests.java
@@ -4,7 +4,6 @@ import static horseshoe.Helper.loadMap;
 
 import java.io.IOException;
 import java.io.StringWriter;
-
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/horseshoe/PartialsTests.java
+++ b/src/test/java/horseshoe/PartialsTests.java
@@ -4,6 +4,7 @@ import static horseshoe.Helper.loadMap;
 
 import java.io.IOException;
 import java.io.StringWriter;
+
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/horseshoe/TemplateTests.java
+++ b/src/test/java/horseshoe/TemplateTests.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -104,10 +105,16 @@ public class TemplateTests {
 
 		assertEquals(" ", new TemplateLoader().load("Simple Test", " ").render(new Settings(), Collections.emptyMap(), new java.io.StringWriter()).toString());
 
-		assertEquals("3", new TemplateLoader().add("Dup", new StringReader("1")).add("Dup", "2").load("Dup", new StringReader("3")).render(new Settings(), Collections.emptyMap(), new java.io.StringWriter()).toString());
+		final TemplateLoader tl1 = new TemplateLoader().add("Dup", new StringReader("1")).add("Dup", "2");
+		tl1.load("Dup", new StringReader("3"));
+		tl1.load("Dup", "55");
+		tl1.load("Dup", Paths.get("fakeFile"), StandardCharsets.UTF_16BE);
+		assertEquals("3", tl1.load("Dup", new StringReader("4")).render(new Settings(), Collections.emptyMap(), new java.io.StringWriter()).toString());
 		new TemplateLoader().add("Dup", new StringReader("1")).close();
 
 		assertEquals("a", new TemplateLoader().add(new TemplateLoader().add("a", "a").load("a")).load("b", "{{>a}}").render(new Settings(), Collections.emptyMap(), new java.io.StringWriter()).toString());
+
+		new TemplateLoader().getIncludeDirectories().add(Paths.get("."));
 	}
 
 	@Test(expected = LoadException.class)


### PR DESCRIPTION
Added some parameterized JUnit tests to test partial include directory functionality. Surprisingly, the only one that passes is not the simple case, the rest of them fail:
```
testPartialFromOtherDirectory[rootIncludeDir  = ./, partialFilePath = Partial, partialNavigationPath = Partial,  preventPartialPathTraversal = true, expectedException = null] | 0.458s | failed
testPartialFromOtherDirectory[rootIncludeDir =  ./test1/test2, partialFilePath = Partial, partialNavigationPath =  ../../Partial, preventPartialPathTraversal = false, expectedException =  null] | 0.055s | passed
testPartialFromOtherDirectory[rootIncludeDir =  ./test1/test2, partialFilePath = Partial, partialNavigationPath =  ../../Partial, preventPartialPathTraversal = true, expectedException =  class horseshoe.LoadException] | 0.044s | failed
testPartialFromOtherDirectory[rootIncludeDir =  ./test1/test3, partialFilePath = test1/test2/Partial,  partialNavigationPath = ../test2/Partial, preventPartialPathTraversal =  false, expectedException = null] | 0.008s | failed
testPartialFromOtherDirectory[rootIncludeDir =  ./test1/test3, partialFilePath = test1/test2/Partial,  partialNavigationPath = ../test2/Partial, preventPartialPathTraversal =  true, expectedException = class horseshoe.LoadException] | 0.006s | failed
```
Granted, I just threw these test cases together without much review, so there may likely a methodological error on my part.