### PR TITLE
Rework safe operators due to syntax ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Horseshoe does not support Mustache lambdas. It foregoes lambdas in favor of an 
 ### Which operators are supported by Horseshoe expressions?
 | Precedence | Operators | Associativity |
 | ---------- | --------- | ------------- |
-| 0 | <code>\{</code>a\*<code>\}</code> \(Array / Map Literal \(Iterating\)\), <br><code>\[</code>a\*<code>\]</code> \(Array / Map Literal\), <br><code>\[:\]</code> \(Empty Map\), <br>a<code>\[</code>b<code>\]</code> \(Lookup\), <br>a<code>?\[</code>b<code>\]</code> \(Safe Lookup\), <br>a<code>\(</code>b\*<code>\)</code> \(Call Method\), <br><code>\(</code>a<code>\)</code> \(Parentheses\), <br>a<code>\.</code>b \(Navigate\), <br>a<code>?\.</code>b \(Safe Navigate\) | Left&nbsp;to&nbsp;right |
+| 0 | <code>\{</code>a\*<code>\}</code> \(Array / Map Literal \(Iterating\)\), <br><code>\[</code>a\*<code>\]</code> \(Array / Map Literal\), <br><code>\[:\]</code> \(Empty Map\), <br>a<code>\[</code>b<code>\]</code> \(Lookup\), <br>a<code>?\[?</code>b<code>\]</code> \(Safe Lookup\), <br>a<code>\(</code>b\*<code>\)</code> \(Call Method\), <br><code>\(</code>a<code>\)</code> \(Parentheses\), <br>a<code>\.</code>b \(Navigate\), <br>a<code>?\.?</code>b \(Safe Navigate\) | Left&nbsp;to&nbsp;right |
 | 2 | <code>\+</code>a \(Unary Plus\), <br><code>\-</code>a \(Unary Minus\), <br><code>~</code>a \(Bitwise Negate\), <br><code>\!</code>a \(Logical Negate\) | Right&nbsp;to&nbsp;left |
 | 3 | a<code>\.\.</code>b \(Range\) | Left&nbsp;to&nbsp;right |
 | 4 | a<code>\*</code>b \(Multiply\), <br>a<code>/</code>b \(Divide\), <br>a<code>%</code>b \(Modulus\) | Left&nbsp;to&nbsp;right |
@@ -57,7 +57,7 @@ Horseshoe does not support Mustache lambdas. It foregoes lambdas in favor of an 
 | 13 | a<code>&#124;&#124;</code>b \(Logical Or\) | Left&nbsp;to&nbsp;right |
 | 14 | a<code>?:</code>b \(Null Coalesce\), <br>a<code>??</code>b \(Null Coalesce \(Alternate\)\), <br>a<code>?</code>b \(Ternary\), <br>a<code>:</code>b \(Pair\) | Right&nbsp;to&nbsp;left |
 | 15 | a<code>=</code>b \(Assign\) | Right&nbsp;to&nbsp;left |
-| 16 | <code>☠</code>a \(Die\) | Left&nbsp;to&nbsp;right |
+| 16 | <code>☠</code>a \(Die\), <br><code>~:&lt;</code>a \(Die \(Alternate\)\) | Left&nbsp;to&nbsp;right |
 | 17 | a<code>,</code>b\* \(Array / Map Separator\), <br>a<code>;</code>b \(Statement Separator\) | Left&nbsp;to&nbsp;right |
 
 ### What extension should be used for Horseshoe template files?

--- a/src/main/java/horseshoe/internal/Accessor.java
+++ b/src/main/java/horseshoe/internal/Accessor.java
@@ -172,11 +172,12 @@ public abstract class Accessor {
 		}
 
 		/**
-		 * Creates a new static method accessor.
+		 * Creates a new class method accessor.
 		 *
 		 * @param parent the parent class for the method
 		 * @param methodSignature the signature of the method in the form [name]:[parameterType0],...
 		 * @param parameterCount the number of parameters that the method takes
+		 * @return the class method accessor, or null if no method could be found
 		 */
 		public static ClassMethodAccessor create(final Class<?> parent, final String methodSignature, final int parameterCount) {
 			final MethodSignature signature = new MethodSignature(methodSignature);
@@ -295,6 +296,7 @@ public abstract class Accessor {
 		 * @param parent the parent class for the method
 		 * @param methodSignature the signature of the method in the form [name]:[parameterType0],...
 		 * @param parameterCount the number of parameters that the method takes
+		 * @return the method accessor, or null if no method could be found
 		 */
 		public static MethodAccessor create(final Class<?> parent, final String methodSignature, final int parameterCount) {
 			final MethodSignature signature = new MethodSignature(methodSignature);

--- a/src/main/java/horseshoe/internal/Expression.java
+++ b/src/main/java/horseshoe/internal/Expression.java
@@ -266,8 +266,8 @@ public final class Expression {
 			} else if (second instanceof Character) {
 				return Character.compare(((Character)first).charValue(), ((Character)second).charValue());
 			}
-		} else if ((first instanceof StringBuilder || first instanceof String) &&
-				(second instanceof StringBuilder || second instanceof String)) {
+		} else if ((first instanceof StringBuilder || first instanceof String || first instanceof Character) &&
+				(second instanceof StringBuilder || second instanceof String || second instanceof Character)) {
 			return first.toString().compareTo(second.toString());
 		} else if (equality) {
 			return (first == null ? second == null : first.equals(second)) ? 0 : 1;
@@ -333,7 +333,7 @@ public final class Expression {
 	 * @param expressions the map used to lookup the index of an expression
 	 * @param identifiers the map used to lookup the index of an identifier
 	 * @param operands the operand stack for the expression
-	 * @param operator the operator to evaluate
+	 * @param operators the operator stack to evaluate
 	 */
 	private static void processOperation(final Map<String, Expression> namedExpressions, final Map<Expression, Integer> expressions, final HashMap<Identifier, Integer> identifiers, final PersistentStack<Operand> operands, final PersistentStack<Operator> operators) {
 		final Operator operator = operators.pop();
@@ -402,7 +402,7 @@ public final class Expression {
 		switch (operator.getString()) {
 		// Array / Map Operations
 		case "[":
-		case "?[":
+		case "?[?":
 			if (left != null) {
 				if (!Object.class.equals(left.type)) {
 					throw new IllegalArgumentException("Unexpected '" + operator.getString() + "' operator applied to " + (left.type == null ? "numeric" : left.type.getName()) + " value, expecting map or array type value");
@@ -639,7 +639,7 @@ public final class Expression {
 			operands.push(new Operand(Object.class, right.toObject(false).addCode(DUP).append(left.builder)));
 			break;
 
-		case "☠": // Die
+		case "\u2620": case "~:<": // Die
 			operands.push(new Operand(Object.class, right.toObject(false).addInvoke(STRING_VALUE_OF).pushNewObject(HaltRenderingException.class).addCode(DUP_X1, SWAP).addInvoke(HALT_EXCEPTION_CTOR_STRING).addCode(ATHROW)));
 			break;
 
@@ -669,6 +669,7 @@ public final class Expression {
 	 * Creates a new expression.
 	 *
 	 * @param location the location of the expression
+	 * @param expressionName the name of the expression
 	 * @param expressionString the trimmed, advanced expression string
 	 * @param namedExpressions the map used to lookup named expressions
 	 * @param horseshoeExpressions true to parse as a horseshoe expression, false to parse as a Mustache variable list

--- a/src/main/java/horseshoe/internal/Identifier.java
+++ b/src/main/java/horseshoe/internal/Identifier.java
@@ -9,7 +9,21 @@ public final class Identifier {
 
 	public static final int UNSTATED_BACKREACH = -1;
 	public static final int NOT_A_METHOD = -1;
-	public static final String PATTERN = "[\\p{L}_\\$][\\p{L}\\p{Nd}_\\$]*";
+
+	private static final String LETTER_CHARACTERS = "\\p{Lu}\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}"; // Character.isLetter()
+	private static final String CHARACTERS = LETTER_CHARACTERS // Derived from Character.isJavaIdentifierPart()
+			+ "\\p{Sc}" // Currency symbol
+			+ "\\p{Pc}" // Connecting punctuation character
+			+ "\\p{Nd}" // Digit
+			+ "\\p{Nl}" // Numeric letter
+			+ "\\p{Mc}" // Combining mark
+			+ "\\p{Mn}" // Non-spacing mark
+			+ "\\u0000-\\u0008\\u000E-\\u001B\\u007F-\\u009F\\p{Zl}\\p{Zp}\\p{Cf}"; // Character.isIdentifierIgnorable()
+
+	public static final String CHARACTER_CLASS = "[" + CHARACTERS + "]";
+	public static final String NEGATED_CHARACTER_CLASS = "[^" + CHARACTERS + "]";
+	public static final String PATTERN = "[" + LETTER_CHARACTERS + "\\p{Nl}\\p{Sc}\\p{Pc}" + "]" // Derived from Character.isJavaIdentifierStart()
+			+ CHARACTER_CLASS + "*"; // Derived from Character.isJavaIdentifierPart()
 
 	private final HashMap<Class<?>, Accessor> accessorDatabase = new LinkedHashMap<>();
 	private final String name;

--- a/src/main/java/horseshoe/internal/Operand.java
+++ b/src/main/java/horseshoe/internal/Operand.java
@@ -63,7 +63,6 @@ final class Operand {
 	 * Generates an operand that is the result of comparing this operand and the other specified operand.
 	 *
 	 * @param other the other operand used to calculate the result
-	 * @param intBranchOpcode the opcode used to compare and branch the two int operands
 	 * @param compareBranchOpcode the opcode used to branch after a compare of the two operands
 	 * @param firstLocalIndex the first local variable index that can be used for temporary storage
 	 * @return the resulting operand from the comparison
@@ -237,10 +236,10 @@ final class Operand {
 	}
 
 	/**
-	 * Converts the operand to an object, combining all builders into the single builder specified. All existing builders are cleared.
+	 * Converts the operand to an object.
 	 *
-	 * @param builder the builder used to combine all other builders
-	 * @return the combined builder that was passed to the method
+	 * @param generateReturn true to generate return instructions rather than place the object on the stack, otherwise false
+	 * @return the resulting object operand
 	 */
 	public MethodBuilder toObject(final boolean generateReturn) {
 		if (type == null) {

--- a/src/main/java/horseshoe/internal/Operator.java
+++ b/src/main/java/horseshoe/internal/Operator.java
@@ -1,12 +1,51 @@
 package horseshoe.internal;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 final class Operator {
+
+	/**
+	 * This represents all allowed ASCII characters that can be used as unary operators.
+	 *
+	 * Notes:
+	 *  - ! probably shouldn't be allowed as it conflicts with Mustache comments ({@code {{! Mustache comment }}}), but it is the most logical "not" operator.
+	 *  - ", ', and ` aren't allowed because they are used in string and identifier literals.
+	 *  - #, &amp;, /, &lt;, &gt;, @, ^ aren't allowed because they conflict with Mustache or Horseshoe tags.
+	 *  - $, _ aren't allowed because they are allowed to start identifier literals.
+	 *  - %, *, :, =, ?, | aren't allowed because they could cause ambiguity in multi-character expressions.
+	 *  - ), ], } aren't allowed because they close other operators.
+	 *  - comma, ; aren't allowed because they are separators.
+	 *  - \ isn't allowed because it is reserved for root scoping.
+	 */
+	private static final String UNARY_OPERATOR_CHARACTERS = "!(+-.[{~";
+
+	/**
+	 * This represents all allowed ASCII characters that can be used as binary operators.
+	 *
+	 * Notes:
+	 *  - ", ', and ` aren't allowed because they are used in string and identifier literals.
+	 *  - $, _ aren't allowed because they are allowed in identifier literals.
+	 *  - ), ], } aren't allowed because they close other operators.
+	 *  - / probably shouldn't be allowed as it can be used as a path separator, but it is the most logical "divide" operator.
+	 *  - \ isn't allowed because it is reserved as a path separator.
+	 */
+	private static final String BINARY_OPERATOR_CHARACTERS = "!#%&(*+,-./:;<=>?@[^{|~";
+
+	private static final String OPERATOR_GE_128_PATTERN = "[\\u0080-\\uFFFF&&[\\p{P}\\p{S}]&&" + Identifier.NEGATED_CHARACTER_CLASS + "]";
+	private static final String REMAINING_OPERATOR_CHARACTERS = ")]}" + BINARY_OPERATOR_CHARACTERS.replaceAll("[" + Pattern.quote(UNARY_OPERATOR_CHARACTERS) + "]+", "");
+
+	private static final Pattern UNARY_OPERATOR_CHARACTER_PATTERN =  Pattern.compile(OPERATOR_GE_128_PATTERN // Allow a single character >= 128...
+			+ "|[" + Pattern.quote(UNARY_OPERATOR_CHARACTERS) + "][" + Pattern.quote(REMAINING_OPERATOR_CHARACTERS) + "]*"); // ...or allow additional non-unary operator characters after initial unary operator character
+	private static final Pattern BINARY_OPERATOR_CHARACTER_PATTERN = Pattern.compile(OPERATOR_GE_128_PATTERN // Allow a single character >= 128...
+			+ "|[" + Pattern.quote(BINARY_OPERATOR_CHARACTERS) + "][" + Pattern.quote(REMAINING_OPERATOR_CHARACTERS) + "]*"); // ...or allow additional non-unary operator characters after initial binary operator character
 
 	// Operator Properties
 	public static final int LEFT_EXPRESSION     = 0x00000001; // Has an expression on the left
@@ -42,11 +81,11 @@ final class Operator {
 		operators.add(new Operator("[",      0,  X_RIGHT_EXPRESSIONS | ALLOW_PAIRS, "Array / Map Literal", "]", 0));
 		operators.add(new Operator("[:]",    0,  0, "Empty Map"));
 		operators.add(new Operator("[",      0,  LEFT_EXPRESSION | RIGHT_EXPRESSION, "Lookup", "]", 1));
-		operators.add(new Operator("?[",     0,  LEFT_EXPRESSION | RIGHT_EXPRESSION | SAFE, "Safe Lookup", "]", 1));
+		operators.add(new Operator("?[?",    0,  LEFT_EXPRESSION | RIGHT_EXPRESSION | SAFE, "Safe Lookup", "]", 1));
 		operators.add(createMethod("(", true));
 		operators.add(new Operator("(",      0,  RIGHT_EXPRESSION, "Parentheses", ")", 1));
 		operators.add(new Operator(".",      0,  LEFT_EXPRESSION | RIGHT_EXPRESSION | NAVIGATION, "Navigate"));
-		operators.add(new Operator("?.",     0,  LEFT_EXPRESSION | RIGHT_EXPRESSION | NAVIGATION | SAFE, "Safe Navigate"));
+		operators.add(new Operator("?.?",    0,  LEFT_EXPRESSION | RIGHT_EXPRESSION | NAVIGATION | SAFE, "Safe Navigate"));
 		operators.add(new Operator("+",      2,  RIGHT_EXPRESSION | RIGHT_ASSOCIATIVITY, "Unary Plus"));
 		operators.add(new Operator("-",      2,  RIGHT_EXPRESSION | RIGHT_ASSOCIATIVITY, "Unary Minus"));
 		operators.add(new Operator("~",      2,  RIGHT_EXPRESSION | RIGHT_ASSOCIATIVITY, "Bitwise Negate"));
@@ -76,12 +115,30 @@ final class Operator {
 		operators.add(new Operator("?",      14, LEFT_EXPRESSION | RIGHT_EXPRESSION | RIGHT_ASSOCIATIVITY | ALLOW_PAIRS, "Ternary"));
 		operators.add(new Operator(":",      14, LEFT_EXPRESSION | RIGHT_EXPRESSION | RIGHT_ASSOCIATIVITY, "Pair"));
 		operators.add(new Operator("=",      15, LEFT_EXPRESSION | RIGHT_EXPRESSION | RIGHT_ASSOCIATIVITY | ASSIGNMENT, "Assign"));
-		operators.add(new Operator("☠",      16, RIGHT_EXPRESSION, "Die"));
+		operators.add(new Operator("\u2620", 16, RIGHT_EXPRESSION, "Die"));
+		operators.add(new Operator("~:<",    16, RIGHT_EXPRESSION, "Die (Alternate)"));
 		operators.add(new Operator(",",      17, LEFT_EXPRESSION | X_RIGHT_EXPRESSIONS | ALLOW_PAIRS | IGNORE_TRAILING | CONTAINER, "Array / Map Separator"));
 		operators.add(new Operator(";",      17, LEFT_EXPRESSION | RIGHT_EXPRESSION | IGNORE_TRAILING, "Statement Separator"));
 
+		// These operators have known assertion failures and may contain ambiguities with other operators or Horseshoe features. These ambiguities have been thoroughly analyzed and deemed acceptable.
+		final Set<String> ignoreFailuresIn = new HashSet<>(Arrays.asList("?[?" /* pseudo-ambiguous '[' */,
+				"?.?" /* ambiguous '.' */,
+				".." /* pseudo-ambiguous '.' */ ));
+
 		for (final Operator operator : operators) {
-			operator.next = OPERATOR_LOOKUP.put(operator.string, operator);
+			final String string = operator.string;
+
+			if (!ignoreFailuresIn.contains(string)) { // Sanity and ambiguity checks for the operators
+				assert string != null && !string.isEmpty() : "Operators cannot consist of a null or empty string";
+
+				if (operator.has(LEFT_EXPRESSION)) { // All binary operators must start with a binary operator character
+					assert BINARY_OPERATOR_CHARACTER_PATTERN.matcher(string).matches() : "Invalid binary operator '" + string + "', must match the following pattern: '" + BINARY_OPERATOR_CHARACTER_PATTERN + "'";
+				} else { // All unary operators must start with a unary operator character
+					assert UNARY_OPERATOR_CHARACTER_PATTERN.matcher(string).matches() : "Invalid unary operator '" + string + "', must match the following pattern: '" + UNARY_OPERATOR_CHARACTER_PATTERN + "'";
+				}
+			}
+
+			operator.next = OPERATOR_LOOKUP.put(string, operator);
 		}
 
 		OPERATORS = Collections.unmodifiableList(operators);
@@ -217,7 +274,8 @@ final class Operator {
 	/**
 	 * Gets if the operator has the given property.
 	 *
-	 * @return true if the operator has the given property, otherwise false
+	 * @param property the property or set of properties to test for
+	 * @return true if the operator has the given property or at least one of a set of properties, otherwise false
 	 */
 	public boolean has(final int property) {
 		return (properties & property) != 0;

--- a/src/test/java/horseshoe/internal/AccessorTests.java
+++ b/src/test/java/horseshoe/internal/AccessorTests.java
@@ -15,7 +15,7 @@ public class AccessorTests {
 
 	@Test
 	public void testStaticFields() throws IOException, LoadException {
-		assertEquals("Values: (0) " + Byte.MAX_VALUE + ", 1) " + Short.MAX_VALUE + ", 2) " + Integer.MAX_VALUE + ", 3) " + Long.MAX_VALUE + ", 4) " + Float.MAX_VALUE + ", 5) " + Double.MAX_VALUE + ", 6) ", new TemplateLoader().load("Static Fields", "Values: {{.badInternal}}{{#Values}}{{#.isFirst}}({{/}}{{.index}}) {{.?.MAX_VALUE}}{{#.hasNext}}, {{/}}{{/}}").render(new Settings(), Helper.loadMap("Values", Helper.loadList(Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class, Object.class)), new java.io.StringWriter()).toString());
+		assertEquals("Values: (0) " + Byte.MAX_VALUE + ", 1) " + Short.MAX_VALUE + ", 2) " + Integer.MAX_VALUE + ", 3) " + Long.MAX_VALUE + ", 4) " + Float.MAX_VALUE + ", 5) " + Double.MAX_VALUE + ", 6) ", new TemplateLoader().load("Static Fields", "Values: {{.badInternal}}{{#Values}}{{#.isFirst}}({{/}}{{.index}}) {{.?.?MAX_VALUE}}{{#.hasNext}}, {{/}}{{/}}").render(new Settings(), Helper.loadMap("Values", Helper.loadList(Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class, Object.class)), new java.io.StringWriter()).toString());
 	}
 
 	@Test

--- a/src/test/java/horseshoe/internal/ExpressionTests.java
+++ b/src/test/java/horseshoe/internal/ExpressionTests.java
@@ -44,7 +44,7 @@ public class ExpressionTests {
 		assertEquals("2", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "[\"1\", \"2\"][1]", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals("1", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "[7: \"1\", \"2\",][7]", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals("2", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "[\"1\", \"blah\": \"2\"][\"blah\"]", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
-		assertEquals("2", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "null?[1] ?? \"2\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
+		assertEquals("2", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "null?[?1] ?? \"2\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals("4", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(1..5)[3]", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals("8", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(10..5)[2]", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals(6, ((int[])new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "10..5", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER)).length);
@@ -130,17 +130,37 @@ public class ExpressionTests {
 
 	@Test (expected = IllegalArgumentException.class)
 	public void testBadCompare() throws ReflectiveOperationException {
-		assertEquals("Should have failed", Expression.compare(false, 5, "5"));
+		Expression.compare(false, 5, "5");
 	}
 
 	@Test (expected = ClassCastException.class)
 	public void testBadCompare2() throws ReflectiveOperationException {
-		assertEquals("Should have failed", Expression.compare(false, "5", 5));
+		Expression.compare(false, "5", 5);
 	}
 
 	@Test (expected = IllegalArgumentException.class)
 	public void testBadCompare3() throws ReflectiveOperationException {
-		assertEquals("Should have failed", Expression.compare(false, new Object(), new Object()));
+		Expression.compare(false, new Object(), new Object());
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void testBadEmpty() throws ReflectiveOperationException {
+		new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "", Collections.emptyMap(), true);
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void testBadEmptyParentheses() throws ReflectiveOperationException {
+		new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "()", Collections.emptyMap(), true);
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void testBadEmptyParentheses2() throws ReflectiveOperationException {
+		new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(,)", Collections.emptyMap(), true);
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void testBadEmptyParentheses3() throws ReflectiveOperationException {
+		new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(a,,)", Collections.emptyMap(), true);
 	}
 
 	@Test (expected = IllegalArgumentException.class)
@@ -166,26 +186,6 @@ public class ExpressionTests {
 	@Test (expected = IllegalArgumentException.class)
 	public void testBadIdentifier5() throws ReflectiveOperationException {
 		new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "1 b", Collections.emptyMap(), true);
-	}
-
-	@Test (expected = IllegalArgumentException.class)
-	public void testBadEmpty() throws ReflectiveOperationException {
-		new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "", Collections.emptyMap(), true);
-	}
-
-	@Test (expected = IllegalArgumentException.class)
-	public void testBadEmptyParentheses() throws ReflectiveOperationException {
-		new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "()", Collections.emptyMap(), true);
-	}
-
-	@Test (expected = IllegalArgumentException.class)
-	public void testBadEmptyParentheses2() throws ReflectiveOperationException {
-		new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(,)", Collections.emptyMap(), true);
-	}
-
-	@Test (expected = IllegalArgumentException.class)
-	public void testBadEmptyParentheses3() throws ReflectiveOperationException {
-		new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(a,,)", Collections.emptyMap(), true);
 	}
 
 	@Test (expected = IllegalArgumentException.class)
@@ -341,7 +341,7 @@ public class ExpressionTests {
 		assertEquals("true, false, true, false",   new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(\"a\" + \"bc\" >= \"ab\" + \"c\") + \", \" + (5 + 8.3 >= 5.31 + 8) + \", \" + (0xFFFFFFFFFFFF - 0xFFFFFFFF0000 >= 0xFFFF) + \", \" + (\"A\" >= \"B\")", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals("false, true, false, true",   new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(\"a\" + \"bc\" <  \"ab\" + \"c\") + \", \" + (5 + 8.3 <  5.31 + 8) + \", \" + (0xFFFFFFFFFFFF - 0xFFFFFFFF0000 <  0xFFFF) + \", \" + (\"A\" <  \"B\")", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals("false, false, false, false", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(\"a\" + \"bc\" >  \"ab\" + \"c\") + \", \" + (5 + 8.3 >  5.31 + 8) + \", \" + (0xFFFFFFFFFFFF - 0xFFFFFFFF0000 >  0xFFFF) + \", \" + (\"A\" >  \"B\")", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
-		assertEquals("false", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(null?.toString() == true?.toString())", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
+		assertEquals("false", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(null?.?toString() == true?.?toString())", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals("true", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "\"a\" + \"b\" == \"ab\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 	}
 
@@ -358,7 +358,12 @@ public class ExpressionTests {
 
 	@Test (expected = HaltRenderingException.class)
 	public void testDie() throws ReflectiveOperationException {
-		assertEquals("Should have died", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "☠ \"Should print out as a severe log statement\"; \"Did not die\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
+		assertEquals("Should have died", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "☠ \"Should die with error\"; \"Did not die\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
+	}
+
+	@Test (expected = HaltRenderingException.class)
+	public void testDie2() throws ReflectiveOperationException {
+		assertEquals("Should have died", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "~:< 'Should die with error'; \"Did not die\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 	}
 
 	@Test
@@ -411,7 +416,7 @@ public class ExpressionTests {
 		assertEquals("true", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "((\"four\".length() == 4) || false)", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals("false", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(null || !!null)", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals("true", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(true || 1)", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
-		assertEquals("true", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(null?.toString() || true?.toString())", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
+		assertEquals("true", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(null?.?toString() || true?.?toString())", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 	}
 
 	@Test
@@ -463,8 +468,8 @@ public class ExpressionTests {
 	public void testSafeOperators() throws ReflectiveOperationException {
 		assertEquals("good", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "null ?? \"good\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 		assertEquals("good", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "\"good\" ?: \"bad\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
-		assertEquals("good", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(null?.toString()) ?? \"good\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
-		assertEquals("7", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(7?.toString()) ?? \"bad\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
+		assertEquals("good", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(null?.?toString()) ?? \"good\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
+		assertEquals("7", new Expression(FILENAME + new Throwable().getStackTrace()[0].getLineNumber(), null, "(7?.?toString()) ?? \"bad\"", Collections.emptyMap(), true).evaluate(new PersistentStack<>(), ContextAccess.CURRENT, null, Settings.DEFAULT_ERROR_LOGGER).toString());
 	}
 
 	@Test


### PR DESCRIPTION
This pull request fixes issues with safe operators related to syntax ambiguity. For example, does `[object?.index:1]` mean "create an array of one item that is equivalent to .index if object is true and 1 if object is false," or does it mean "create a map of one item with a key equivalent to object?.index and a value of 1?" This is resolved by forcing all multi-character operators to end in a character associated with a binary operation. (These checks are added as asserts in the `Operator` class to ensure no operators violate these rules at test time.) In this particular case the `?` character is added to the end of the safe operators that do not end in a character associated with a binary operation.